### PR TITLE
html] Fixed the dependent package versions

### DIFF
--- a/html/package.json
+++ b/html/package.json
@@ -19,14 +19,14 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "ilib": "^14.13.0",
+    "ilib": "^14.19.0",
     "ilib-resbundler": "^1.1.0",
-    "ilib-scanner": "^1.3.1",
+    "ilib-scanner": "^1.4.0",
     "ilib-webpack-loader": "^1.3.1",
     "ilib-webpack-plugin": "^1.3.0",
-    "webpack": "^5.69.1"
+    "webpack": "^4.46.0"
   },
   "devDependencies": {
-    "webpack-cli": "^4.9.2"
+    "webpack-cli": "^3.3.12"
   }
 }

--- a/html/package.json
+++ b/html/package.json
@@ -2,10 +2,7 @@
   "name": "ilib-on-html",
   "version": "1.0.0",
   "description": "",
-  "main": "ilib-include.js",
-  "directories": {
-    "lib": "lib"
-  },
+  "main": "index.html",
   "scripts": {
     "scan": "ilib-scanner --assembly=assembled --locales=ko-KR,es-ES ilib-include.js",
     "build": "webpack",
@@ -18,15 +15,13 @@
     "email": "goun.lee@lge.com"
   },
   "license": "Apache-2.0",
-  "dependencies": {
+  "devDependencies": {
     "ilib": "^14.19.0",
     "ilib-resbundler": "^1.1.0",
     "ilib-scanner": "^1.4.0",
     "ilib-webpack-loader": "^1.3.1",
     "ilib-webpack-plugin": "^1.3.0",
-    "webpack": "^4.46.0"
-  },
-  "devDependencies": {
+    "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12"
   }
 }


### PR DESCRIPTION
In order to work properly,
- the `ilib-scanner` should be the latest
- and the `webpack` should not be the latest.