### PR TITLE
Update sample to ilib-lint v2.0.0 and updated plugins

### DIFF
--- a/lint/README.md
+++ b/lint/README.md
@@ -3,9 +3,8 @@
 A sample to demonstrate how to call and use the ilib-lint tool to find
 i18n problems in your code.
 
-For now, the lint tool can only check for problems in xliff files. As it
-matures, it will be able to check for problems in source files of various
-types based on plugins.
+The lint tool can check for problems in xliff files, or in source files 
+of various types, based on plugins.
 
 # Usage
 
@@ -40,7 +39,7 @@ example of this file.
 
 ## License
 
-Copyright © 2023, JEDLSoft
+Copyright © 2023-2024, JEDLSoft
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -56,6 +55,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 ## Release Notes
+
+### v2.0.0
+
+- added support for ilib-lint v2.0.0
+- can now parse source code files and lint them as well, not just
+  xliff files
+    - included a sample jsx file parsed by the JSXParser provided
+	  by the ilib-lint-react plugin, and using rules implemented
+	  in the same plugin
 
 ### v1.1.0
 

--- a/lint/ilib-lint-config.json
+++ b/lint/ilib-lint-config.json
@@ -19,10 +19,12 @@
     },
     "filetypes": {
         "jsx": {
-            "ruleset": [ "generic", "react" ]
+            "parsers": [ "JSXParser" ],
+            "ruleset": [ "generic", "react", "source" ]
         },
         "python" : {
-            "ruleset": [ "generic", "python", "python-gnu" ]
+            // "parsers": [ "PythonParser" ],
+            "ruleset": [ "generic", "python", "python-gnu", "source" ]
         },
         "xliff": {
             "ruleset": [ "generic", "python", "python-gnu" ]

--- a/lint/package.json
+++ b/lint/package.json
@@ -54,9 +54,9 @@
         "test": "echo success"
     },
     "dependencies": {
-        "ilib-lint": "^1.7.0",
-        "ilib-lint-python": "^1.1.0",
-        "ilib-lint-python-gnu": "^1.2.0",
-        "ilib-lint-react": "^1.0.0"
+        "ilib-lint": "^2.0.0",
+        "ilib-lint-python": "^2.0.0",
+        "ilib-lint-python-gnu": "^2.0.0",
+        "ilib-lint-react": "^2.0.0"
     }
 }

--- a/lint/package.json
+++ b/lint/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-sample",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "main": "./src/index.js",
     "description": "Sample application that demostrates how to use the ilib-lint tool with python strings",
     "keywords": [

--- a/lint/src/test.jsx
+++ b/lint/src/test.jsx
@@ -1,0 +1,21 @@
+import { defineMessages } from 'react-intl';
+
+const messages = defineMessages({
+    message1: {
+        id: "myprogram.message1",
+        description: "this is a test",
+        defaultMessage: "{count, plural, one {This is singular} other {This is plural}}"
+    },
+    message2: {
+        id: "myprogram.message2",
+        description: "this is also a test",
+        defaultMessage: "{count, plural, one {This is singular} other {This is plural}"
+    },
+    message3: {
+        id: "myprogram.message3",
+        description: "this is also a test",
+        defaultMessage: "{count, plural, one {This is {singular} other {This is plural}}"
+    }
+});
+
+export default messages;

--- a/lint/src/test2.jsx
+++ b/lint/src/test2.jsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { FormattedMessage } from 'react-intl';
+import { targetingApi } from 'components/targeting/targetingApi.js';
+import TargetComponent from 'components/targeting/TargetComponent.jsx';
+import Modal from 'components/targeting/BaseModal.jsx';
+
+import { messages } from './messages.js';
+
+const SuccessModal = () => {
+    const { onClose } = targetingApi();
+    return <TargetComponent shouldTarget="true" target="">
+            <Modal
+                className="SuccessModal"
+                isOpen
+                onRequestClose={onClose}
+                title={intl.formatMessage(message.successModalTitle)}
+            >
+                <div className="modalBody">
+                    Success! Now try upgrading to unlock more functionality.
+                    <br/>
+                    <FormattedMessage
+                        {...messages.successModalBody2}
+                        values={{
+                            linkToUpgradeModal: (
+                                <UpgradeModalButton tracking="upgradeLink">
+                                    <FormattedMessage {...messages.upgradeLinkLabel} />
+                                </UpgradeModalButton>
+                            )
+                        }}
+                    />
+                </div>
+            </Modal>
+        </TargetComponent>;
+}
+
+export default SuccessModal;


### PR DESCRIPTION
- can now parse source code files and lint them as well, not just xliff files
    - included a sample jsx file parsed by the JSXParser provided by the ilib-lint-react plugin, and using rules implemented in the same plugin
